### PR TITLE
Numerical parsers code reuse

### DIFF
--- a/numerical-parsers/utils.coffee
+++ b/numerical-parsers/utils.coffee
@@ -1,0 +1,10 @@
+"use strict"
+
+module.exports =
+  defaultVal: 0
+  isValidCheck: (input, regex) -> input.some (val) -> regex.test val
+  reducer: (base, bits) ->
+    (result, element) ->
+      result += element * base ** bits
+      bits -= 1
+      result

--- a/trinary/trinary.coffee
+++ b/trinary/trinary.coffee
@@ -1,18 +1,14 @@
+"use strict"
+
+utils = require "../numerical-parsers/utils"
+
 module.exports = class Trinary
   constructor: (input) ->
     @input = input.split ''
-    @isNotTrinary = @input.some (char) -> /[^0-2]/.test char
-    @default = 0
+    @isNotTrinary = utils.isValidCheck @input, /[^0-2]/
 
   toDecimal: ->
     if @isNotTrinary
-      @default
+      utils.defaultVal
     else
-      bits = @input.length - 1
-      @input
-        .map((i) -> +i)
-        .reduce ((result, element) ->
-          result += element * (3 ** bits)
-          bits -= 1
-          result
-        ), @default
+      @input.map((i) -> +i).reduce utils.reducer(3, @input.length - 1), 0


### PR DESCRIPTION
For the sake of keeping all logic in exercism submissions, I’ll use Trinary as an example of how I’d reuse the code for these things, without introducing class inheritance.
